### PR TITLE
Add unit test for AUC curve plotting

### DIFF
--- a/tests/test_plot_auc_curves.py
+++ b/tests/test_plot_auc_curves.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+# Ensure src directory is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from analysis_functions import plot_auc_curves
+
+
+def test_perfect_predictions_auc_is_one(monkeypatch):
+    # Avoid opening plot windows
+    monkeypatch.setattr(plt, "show", lambda *args, **kwargs: None)
+
+    y_true = [0, 1, 0, 1]
+    y_scores = [0, 1, 0, 1]
+
+    auc_scores = plot_auc_curves(y_true, y_scores)
+
+    assert auc_scores["Model"] == 1.0
+


### PR DESCRIPTION
## Summary
- add pytest that ensures `plot_auc_curves` returns an AUC of 1.0 with perfect predictions
- use matplotlib's Agg backend and patch `plt.show`

------
https://chatgpt.com/codex/tasks/task_b_68768bee6cb883299ee1cc0f9336061f