### PR TITLE
Add error-by-group and tabulation outputs

### DIFF
--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -1,5 +1,5 @@
 """Analysis utilities and model evaluation."""
-from . import plots, report
+from . import plots, report, tabulation
 from .evaluator import ModelEvaluator
 
-__all__ = ["plots", "report", "ModelEvaluator"]
+__all__ = ["plots", "report", "tabulation", "ModelEvaluator"]

--- a/src/analysis/evaluator.py
+++ b/src/analysis/evaluator.py
@@ -6,8 +6,7 @@ from typing import Any, Dict, Iterable, Optional
 import numpy as np
 import pandas as pd
 
-from . import plots
-from . import report
+from . import plots, report, tabulation
 
 
 class ModelEvaluator:
@@ -74,6 +73,16 @@ class ModelEvaluator:
             **kwargs,
         )
 
+    def plot_error_by_group_grid(self, group_cols: Iterable[str], **kwargs) -> Any:
+        """Plot prediction error by multiple grouping variables."""
+        return plots.plot_error_by_group_grid(
+            self.data,
+            self.actual_col,
+            self.predicted_col,
+            group_cols=group_cols,
+            **kwargs,
+        )
+
     # ------------------------------------------------------------------
     # Comparison utilities
     def compare_models_discrepancy(
@@ -92,7 +101,14 @@ class ModelEvaluator:
 
     # ------------------------------------------------------------------
     # Report
-    def export_html(self, output_html: str = "model_analysis.html", title: str | None = None) -> None:
+    def export_html(
+        self,
+        output_html: str = "model_analysis.html",
+        title: str | None = None,
+        *,
+        error_group_cols: Iterable[str] | None = None,
+        tabulation_vars: Iterable[str] | None = None,
+    ) -> None:
         report.generate_model_analysis_report(
             self.data,
             self.actual_col,
@@ -100,5 +116,41 @@ class ModelEvaluator:
             split_col=self.split_col,
             exposure_col=self.exposure_col,
             output_html=output_html,
+            error_group_cols=error_group_cols,
+            tabulation_vars=tabulation_vars,
             title=title,
+        )
+
+    def tabulate(
+        self,
+        group_vars: Iterable[str],
+        *,
+        output_html: str | None = None,
+        n_bins: int = 5,
+        factor: bool = False,
+    ) -> str | None:
+        """Return HTML tabulations or write them to ``output_html`` if provided."""
+        if output_html:
+            tabulation.generate_and_save_tabulations(
+                df=self.data,
+                prediction_col=self.predicted_col,
+                truth_col=self.actual_col,
+                group_vars=list(group_vars),
+                split_col=self.split_col,
+                weights_col=self.exposure_col,
+                n_bins=n_bins,
+                factor=factor,
+                output_html=output_html,
+            )
+            return None
+
+        return tabulation.generate_tabulations_html(
+            df=self.data,
+            prediction_col=self.predicted_col,
+            truth_col=self.actual_col,
+            group_vars=list(group_vars),
+            split_col=self.split_col,
+            weights_col=self.exposure_col,
+            n_bins=n_bins,
+            factor=factor,
         )

--- a/src/analysis/plots.py
+++ b/src/analysis/plots.py
@@ -7,6 +7,7 @@ from typing import Dict, Iterable, Sequence
 
 import matplotlib.pyplot as plt
 import pandas as pd
+import numpy as np
 import seaborn as sns
 from sklearn.metrics import auc, roc_curve
 
@@ -155,24 +156,33 @@ def plot_error_by_group(df, target_col, pred_col, group_col, bins=10, ax=None):
     ax1.set_xticklabels(ax1.get_xticklabels(), rotation=45, ha='right')
     ax1.set_title(f'Error by {group_col}')
 
-def plot_error_by_group_grid(df, target_col, pred_col, group_cols, bins=10, ncols=2, figsize=(6, 4)):
-    """
-    Plot prediction error and count by multiple group columns using shared grid layout.
-    Calls `plot_error_by_group` for each plot.
-    """
+def plot_error_by_group_grid(
+    df,
+    target_col,
+    pred_col,
+    group_cols,
+    bins=10,
+    ncols=2,
+    figsize=(6, 4),
+) -> plt.Figure:
+    """Return a grid of error-by-group plots."""
     n_rows = -(-len(group_cols) // ncols)  # ceiling division
-    fig, axes = plt.subplots(n_rows, ncols, figsize=(figsize[0]*ncols, figsize[1]*n_rows))
-    axes = np.array(axes).reshape(-1)  # flatten even if 1D
+    fig, axes = plt.subplots(
+        n_rows, ncols, figsize=(figsize[0] * ncols, figsize[1] * n_rows)
+    )
+    axes = np.array(axes).reshape(-1)
 
     for i, group_col in enumerate(group_cols):
-        plot_error_by_group(df, target_col, pred_col, group_col, bins=bins, ax=axes[i])
+        plot_error_by_group(
+            df, target_col, pred_col, group_col, bins=bins, ax=axes[i]
+        )
 
-    # Hide any extra axes
     for j in range(len(group_cols), len(axes)):
         fig.delaxes(axes[j])
 
     plt.tight_layout()
     plt.show()
+    return fig
 
 def plot_target_vs_predictors(
     df, target, predictors, bins: int = 10,

--- a/src/analysis_functions.py
+++ b/src/analysis_functions.py
@@ -5,5 +5,6 @@ cumulative_gain_plot = plots.cumulative_gain_plot
 percent_gain_plot = plots.percent_gain_plot
 plot_auc_curves = plots.plot_auc_curves
 plot_error_by_group = plots.plot_error_by_group
+plot_error_by_group_grid = plots.plot_error_by_group_grid
 plot_target_vs_predictors = plots.plot_target_vs_predictors
 plot_variable_distributions = plots.plot_variable_distributions


### PR DESCRIPTION
## Summary
- return `Figure` from `plot_error_by_group_grid`
- expose tabulation utilities via `generate_tabulations_html`
- include error-by-group plots and tabulations in HTML reports
- allow `ModelEvaluator` to call these new utilities
- expose new helper from `analysis_functions`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_687699430a14832986e0257ea127b183