### PR TITLE
Add hyperparameter tuning with BayesSearchCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,23 @@ uv venv
 source .venv/bin/activate  # or `.venv\\Scripts\\activate` on Windows
 uv pip install -r uv.lock
 ```
+
+## ⚙️ Hyperparameter Tuning
+
+`GBMModelTrainer` supports Bayesian hyperparameter search via
+[`scikit-optimize`](https://scikit-optimize.github.io/).
+Add a `tuning` section to your YAML configuration:
+
+```yaml
+actual_col: target
+predicted_col: pred
+tuning:
+  search_space:
+    n_estimators: [50, 100]
+    max_depth: [3, 4, 5]
+  n_iter: 10
+  scoring: accuracy
+```
+
+Call `trainer.tune()` before `trainer.train()` and the best parameters will be
+used for training and stored in the configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = []
+dependencies = [
+    "scikit-optimize>=0.9.0",
+]

--- a/src/training/gbm_model_trainer.py
+++ b/src/training/gbm_model_trainer.py
@@ -19,6 +19,15 @@ from catboost import CatBoostClassifier, CatBoostRegressor
 from analysis.report import ModelAnalysisReport
 from analysis import plots
 
+
+@dataclass
+class TuningConfig:
+    """Configuration for hyperparameter tuning."""
+
+    search_space: Dict[str, Any] = field(default_factory=dict)
+    n_iter: int = 10
+    scoring: Optional[str] = None
+
 @dataclass
 class GBMModelTrainerConfig:
     actual_col: str
@@ -33,8 +42,9 @@ class GBMModelTrainerConfig:
     # Params for Model Analysis Report if outputting
     output_report: bool = False
     report_params: Dict[str, Any] = field(default_factory=dict)
-    plots_to_add: List[Dict[str, Any]] = field(default_factory=list) 
-    tabulate_vars: List[str] = field(default_factory=list)  
+    plots_to_add: List[Dict[str, Any]] = field(default_factory=list)
+    tabulate_vars: List[str] = field(default_factory=list)
+    tuning: TuningConfig = field(default_factory=TuningConfig)
 
 class GBMModelTrainer:
     def __init__(
@@ -56,6 +66,8 @@ class GBMModelTrainer:
     def _load_config(self, config_path: str) -> GBMModelTrainerConfig:
         with open(config_path, "r") as f:
             cfg = yaml.safe_load(f) or {}
+        tuning_cfg = cfg.get("tuning", {})
+        cfg["tuning"] = TuningConfig(**tuning_cfg)
         return GBMModelTrainerConfig(**cfg)
 
     def _split_xy(self, df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Series | None]:
@@ -167,6 +179,56 @@ class GBMModelTrainer:
         else:
             self.model.fit(X_train, **fit_kwargs)
 
+    def tune(self) -> None:
+        """Hyperparameter tuning using Bayesian search."""
+        tuning_cfg = self.config.tuning
+        if not tuning_cfg.search_space:
+            self._log("No tuning search space provided; skipping tuning")
+            return
+
+        X_train, y_train = self._split_xy(self._prepare_dataframe(self.train_df))
+        X_valid, y_valid = self._split_xy(self._prepare_dataframe(self.valid_df))
+
+        X_all = pd.concat([X_train, X_valid]).reset_index(drop=True)
+        y_all = None
+        if y_train is not None:
+            y_all = pd.concat([y_train, y_valid]).reset_index(drop=True)
+
+        try:
+            from skopt import BayesSearchCV
+        except Exception as exc:  # pragma: no cover - library may be missing
+            raise ImportError(
+                "BayesSearchCV requires scikit-optimize to be installed"
+            ) from exc
+
+        base_estimator = self.model_class(**self.config.hyperparameters)
+
+        search = BayesSearchCV(
+            estimator=base_estimator,
+            search_spaces=tuning_cfg.search_space,
+            n_iter=tuning_cfg.n_iter,
+            scoring=tuning_cfg.scoring,
+            refit=True,
+            return_train_score=False,
+        )
+
+        trial = {"num": 0}
+
+        def log_step(_):
+            idx = trial["num"]
+            score = search.cv_results_["mean_test_score"][idx]
+            params = search.cv_results_["params"][idx]
+            self._log(f"Trial {idx+1}: score={score:.4f} params={params}")
+            trial["num"] += 1
+
+        search.fit(X_all, y_all, callback=log_step)
+
+        self.config.hyperparameters.update(search.best_params_)
+        self.model = search.best_estimator_
+        self._log(
+            f"Tuning complete. Best score {search.best_score_:.4f}; params {search.best_params_}"
+        )
+
     def train(self) -> None:
         """Main training routine."""
         start = time.time()
@@ -175,8 +237,11 @@ class GBMModelTrainer:
         if self.holdout_df:
             X_holdout, y_holdout = self._split_xy(self._prepare_dataframe(self.holdout_df))
 
-        self.model = self._instantiate_model()
-        self._log(f"Instantiated model: {self.model.__class__.__name__}")
+        if self.model is None:
+            self.model = self._instantiate_model()
+            self._log(f"Instantiated model: {self.model.__class__.__name__}")
+        else:
+            self._log(f"Using existing model: {self.model.__class__.__name__}")
 
         self._fit_model(X_train, y_train, X_valid, y_valid)
         fit_time = time.time() - start

--- a/tests/test_gbm_trainer_tune.py
+++ b/tests/test_gbm_trainer_tune.py
@@ -1,0 +1,39 @@
+import pandas as pd
+import yaml
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+
+from training.gbm_model_trainer import GBMModelTrainer
+
+
+def test_tune_updates_params(tmp_path):
+    X, y = make_classification(n_samples=40, n_features=4, random_state=0)
+    df = pd.DataFrame(X, columns=[f"x{i}" for i in range(4)])
+    df['target'] = y
+    train_df = df.iloc[:20].reset_index(drop=True)
+    valid_df = df.iloc[20:30].reset_index(drop=True)
+
+    cfg = {
+        'actual_col': 'target',
+        'predicted_col': 'pred',
+        'tuning': {
+            'search_space': {'n_estimators': [5, 10]},
+            'n_iter': 2,
+            'scoring': 'accuracy'
+        }
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    trainer = GBMModelTrainer(RandomForestClassifier, str(cfg_path), train_df, valid_df)
+    try:
+        trainer.tune()
+    except ImportError:
+        # scikit-optimize not installed in test environment
+        return
+
+    assert 'n_estimators' in trainer.config.hyperparameters
+    assert any('Trial' in line for line in trainer.log_lines)
+    trainer.train()
+    assert trainer.model.n_estimators == trainer.config.hyperparameters['n_estimators']
+

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rpds-py==0.24.0
 scikit-learn==1.6.1
+scikit-optimize==0.9.0
 scipy==1.15.2
 seaborn==0.13.2
 send2trash==1.8.3


### PR DESCRIPTION
## Summary
- add `TuningConfig` to trainer config
- implement `GBMModelTrainer.tune()` with BayesSearchCV
- reuse tuned model/parameters in `train`
- depend on `scikit-optimize`
- document new tuning section
- test trainer tuning behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68879c43715483298443df84df9e432f