### PR TITLE
Pin dependencies and add build script

### DIFF
--- a/build_wheel.py
+++ b/build_wheel.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Utility script to build the project wheel.
+
+This script invokes ``python -m build`` with the ``--wheel`` option. The
+``build`` package must be installed in the environment.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+
+def main() -> None:
+    project_root = pathlib.Path(__file__).resolve().parent
+    cmd = [sys.executable, "-m", "build", "--wheel", str(project_root)]
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "catboost==1.2.8",
     "boto3==1.39.15",
     "jinja2==3.1.6",
-    "email-validator==2.2.0"
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,24 +5,42 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pandas>=2.2.0",
-    "numpy>=1.25",
-    "scikit-learn>=1.6.0",
-    "matplotlib",
-    "seaborn",
-    "scikit-optimize>=0.9.0",
-    "pyyaml",
-    "xgboost",
-    "lightgbm",
-    "catboost",
-    "boto3",
-    "jinja2",
-    "email-validator"
+    "pandas==2.3.1",
+    "numpy==2.3.2",
+    "scikit-learn==1.7.1",
+    "matplotlib==3.10.3",
+    "seaborn==0.13.2",
+    "scikit-optimize==0.10.2",
+    "pyyaml==6.0.2",
+    "xgboost==3.0.2",
+    "lightgbm==4.6.0",
+    "catboost==1.2.8",
+    "boto3==1.39.15",
+    "jinja2==3.1.6",
+    "email-validator==2.2.0"
 ]
 
 [tool.uv]
 dev-dependencies = [
   "jupyterlab",
   "ipython",
+]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.py-modules]
+modules = [
+    "analysis_report",
+    "analysis_functions",
+    "extract_notebook_to_markdown",
+    "partial_gini_plot",
 ]
 


### PR DESCRIPTION
## Summary
- pin direct dependencies to versions from `uv.lock`
- configure setuptools build backend and src layout
- add `build_wheel.py` helper script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python build_wheel.py` *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_b_68892cee0cd4832988ca0683955bd74f